### PR TITLE
chore: add SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -44,6 +44,8 @@ repository:
         comment: ClusterImageCatalog/ImageCatalog manifests for PostgreSQL operand images
       - uri: https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs-extensions
         comment: ClusterImageCatalog/ImageCatalog manifests for PostgreSQL extension images
+      - uri: https://github.com/cloudnative-pg/artifacts/tree/main/bundles
+        comment: OLM (Operator Lifecycle Manager) bundles, one directory per released version
 
   security:
     tools:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -39,7 +39,11 @@ repository:
     automated-pipeline: true
     distribution-points:
       - uri: https://github.com/cloudnative-pg/artifacts/blob/release-{version}/manifests/operator-manifest.yaml
-        comment: Kubernetes manifests
+        comment: Kubernetes manifests for the operator
+      - uri: https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs
+        comment: ClusterImageCatalog/ImageCatalog manifests for PostgreSQL operand images
+      - uri: https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs-extensions
+        comment: ClusterImageCatalog/ImageCatalog manifests for PostgreSQL extension images
 
   security:
     tools:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,72 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-08-04'
+  last-reviewed: '2026-08-04'
+  url: https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/SECURITY-INSIGHTS.yml
+  # reference the main SECURITY-INSIGHTS file from CNPG repo
+  project-si-source: https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/SECURITY-INSIGHTS.yml
+
+repository:
+  url: https://github.com/cloudnative-pg/artifacts
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Gabriele Bartolini
+      email: gabriele.bartolini@enterprisedb.com
+      primary: true
+    - name: Francesco Canovai
+      email: francesco.canovai@enterprisedb.com
+      primary: false
+    - name: Leonardo Cecchi
+      email: leonardo.cecchi@enterprisedb.com
+      primary: false
+    - name: Marco Nenciarini
+      email: marco.nenciarini@enterprisedb.com
+      primary: false
+    - name: Armando Ruocco
+      email: armando.ruocco@enterprisedb.com
+      primary: false
+    - name: Niccolò Fei
+      email: niccolo.fei@enterprisedb.com
+      primary: false
+  license:
+    url: https://www.apache.org/licenses/LICENSE-2.0
+    expression: Apache-2.0
+
+  release:
+    automated-pipeline: true
+    distribution-points:
+      - uri: https://github.com/cloudnative-pg/artifacts/blob/release-{version}/manifests/operator-manifest.yaml
+        comment: Kubernetes manifests
+
+  security:
+    tools:
+      - name: Dependabot
+        type: SCA
+        rulesets: ["default"]
+        results: {}
+        comment: |
+          No dedicated CI workflows in this repo -- content is generated and
+          committed by other repos' pipelines (see repo-policy.yaml's
+          category: automated in cloudnative-pg/cnpg-infra). Dependabot
+          security updates and GitHub's default code-scanning setup are
+          still enabled at the repo-settings level, org-wide.
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+      - name: GitHub Code Scanning
+        type: SAST
+        rulesets: ["default"]
+        results: {}
+        comment: GitHub's default CodeQL setup, enabled at the repo-settings level.
+        integration:
+          adhoc: false
+          ci: false
+          release: false
+
+    assessments:
+      self:
+        comment: Refer to the main project.


### PR DESCRIPTION
Adds a `SECURITY-INSIGHTS.yml` for this repo, modeled on [cloudnative-pg/postgres-containers's file](https://github.com/cloudnative-pg/postgres-containers/blob/main/SECURITY-INSIGHTS.yml): repository-scoped, pointing back to the main project's file via `header.project-si-source`, with this repo's own core-team (matching `cloudnative-pg/cnpg-infra`'s `repo-tiers.yaml` owners), license, release distribution points, and security tooling — verified against this repo's actual CI workflows and repo settings rather than copied from another repo.

Part of extending `SECURITY-INSIGHTS.yml` coverage to every Class A repo (see `cnpg-infra/repo-tiers.yaml`), starting with this one.

Assisted-by: Claude